### PR TITLE
Import of self signed certificates into the tomcat

### DIFF
--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -32,9 +32,8 @@ ONBUILD COPY . $CATALINA_HOME/webapps/ROOT/
 
 ### Change to user with only www-data permissions
 ONBUILD RUN set -x ; \
-    adduser --disabled-password --system --ingroup www-data $COMPONENT; \
-    chown -R $COMPONENT:www-data $CATALINA_HOME /scripts/ /run/secrets/ /docker/; \
+    adduser --disabled-password --ingroup www-data $COMPONENT; \
+    chown -R $COMPONENT:www-data $CATALINA_HOME /scripts/ /run/secrets/; \
     chmod -R 755 $CATALINA_HOME /scripts/;
-ONBUILD USER $COMPONENT:www-data
 
 ENTRYPOINT ["/scripts/tomcat_entrypoint.sh"]

--- a/tomcat/scripts/tomcat_entrypoint.sh
+++ b/tomcat/scripts/tomcat_entrypoint.sh
@@ -61,9 +61,9 @@ if [ "$DEBUG" = 'true' ]; then
 	export JPDA_ADDRESS=1099;
 	export JPDA_TRANSPORT=dt_socket;
 	echo "Info: starting $COMPONENT tomcat with debug mode. Debug port is set to $JPDA_ADDRESS and JPDA_TRANSPORT is set to $JPDA_TRANSPORT";
-	exec catalina.sh jpda run;
+	su -c 'exec catalina.sh jpda run;' $COMPONENT
 else
   ## Starting tomcat in productive mode
   echo "Info: starting $COMPONENT tomcat ...";
-	exec catalina.sh run;
+	su -c 'exec catalina.sh run;' $COMPONENT
 fi


### PR DESCRIPTION
This PR ist based on [https://github.com/samply/share-client/pull/27](https://github.com/samply/share-client/pull/27)

Additionally to the changes introduced there, it was also necessary to change the timing then a non-root user will be used in the container. Before the non-root user was used for the entrypoint scripts and now it will be used only for running the tomcat.