### PR TITLE
fix: Removed RemoteIPValve configuration from reverseproxy configuration

### DIFF
--- a/tomcat/config/server.reverseproxy.patch
+++ b/tomcat/config/server.reverseproxy.patch
@@ -13,14 +13,3 @@
      <!-- A "Connector" using the shared thread pool-->
      <!--
      <Connector executor="tomcatThreadPool"
-@@ -165,6 +168,10 @@
-                prefix="localhost_access_log" suffix=".txt"
-                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
- 
-+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
-+               remoteIpHeader="x-forwarded-for"
-+               proxiesHeader="x-forwarded-by"
-+               protocolHeader="x-forwarded-proto" />
-       </Host>
-     </Engine>
-   </Service>


### PR DESCRIPTION
Before this change, custom ports like 8082 didn't work with reverseproxies.
The RemoteIPValve has a configuration parameter "httpServerPort", that will default to 80 if not defined. This will cause Adresses read from the Application by using "request.getRequestURL()" to include the wrong port.
