### PR TITLE
perf: Switch user with USER statement now

### DIFF
--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -29,4 +29,5 @@ ONBUILD RUN set -x ; \
     chown -R $COMPONENT:www-data $CATALINA_HOME /docker/ /run/secrets/; \
     chmod -R 755 $CATALINA_HOME /docker/;
 
+ONBUILD USER $COMPONENT
 ENTRYPOINT ["/docker/tomcat_entrypoint.sh"]

--- a/tomcat/scripts/tomcat_entrypoint.sh
+++ b/tomcat/scripts/tomcat_entrypoint.sh
@@ -62,9 +62,9 @@ if [ "$DEBUG" = 'true' ]; then
 	export JPDA_ADDRESS=1099;
 	export JPDA_TRANSPORT=dt_socket;
 	echo "Info: starting $COMPONENT tomcat with debug mode. Debug port is set to $JPDA_ADDRESS and JPDA_TRANSPORT is set to $JPDA_TRANSPORT";
-	su -c 'exec catalina.sh jpda run;' $COMPONENT
+	exec catalina.sh jpda run;
 else
   ## Starting tomcat in productive mode
   echo "Info: starting $COMPONENT tomcat ...";
-	su -c 'exec catalina.sh run;' $COMPONENT
+	exec catalina.sh run;
 fi


### PR DESCRIPTION
The 'su -c' resulted in multiple processes running in the
container, which finally resulted in long shutdown times