### PR TITLE
Decreased Tomcat Base Version from 9 to 10

### DIFF
--- a/.github/workflows/tomcat-common-ci.yml
+++ b/.github/workflows/tomcat-common-ci.yml
@@ -64,7 +64,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v1
@@ -95,7 +95,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-ARG TOMCAT_VERSION="10-jdk8-temurin"
+ARG TOMCAT_VERSION="9-jdk8-temurin"
 FROM tomcat:$TOMCAT_VERSION
 MAINTAINER Torben Brenner "t.brenner@dkfz-heidelberg.de"
 ### Environment Variables need to be set at build time


### PR DESCRIPTION
This is necessary because one of the dependening components fails to start with tomcat 10. For the future we should consider using a matrix build with proper naming of the different versions.