### PR TITLE
fix: Replaced Anonymous Volume with mkdir

### DIFF
--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -10,9 +10,6 @@ ONBUILD ENV COMPONENT=$COMPONENT
 ONBUILD ARG MANDATORY_VARIABLES=""
 ONBUILD ENV MANDATORY_VARIABLES=$MANDATORY_VARIABLES
 
-# mount point for certificates provided by users of the final image
-VOLUME ["/docker/custom-certs"]
-
 ### ADD scripts that will run on container startup
 ### ADD config files for tomcat configuration. These files will be processed in tomcat_entrypoint.sh
 ADD ./tomcat/scripts/tomcat_entrypoint.sh ./tomcat/config/server.reverseproxy.patch ./tomcat/config/server.relaxedQueryChars.patch ./scripts/common_entrypoint.sh ./scripts/proxify.sh /docker/
@@ -28,6 +25,7 @@ RUN sed -i 's/^# localnet /localnet /;s/^socks.*$/http PROXYIP PROXYPORT/' /etc/
 ONBUILD RUN set -x ; \
     adduser --disabled-password --ingroup www-data $COMPONENT; \
     chown -R $COMPONENT:www-data $CATALINA_HOME /docker/ /usr/local/share/ca-certificates/ $JAVA_HOME/jre/lib/security/cacerts /etc/ssl/certs/ /run/secrets/; \
+    mkdir /docker/custom-certs/; \
     chmod -R 755 $CATALINA_HOME /docker/;
 
 ONBUILD USER $COMPONENT


### PR DESCRIPTION
The Volume Statement in Dockerfile resulted in creating empty unnamed volumes on Servers.