### PR TITLE
fix: allow larger header size

### DIFF
--- a/tomcat/config/server.reverseproxy.patch
+++ b/tomcat/config/server.reverseproxy.patch
@@ -1,6 +1,6 @@
 --- tomcat/config/server.xml	2023-09-08 14:42:28.509706700 +0200
 +++ tomcat/config/server.docker.xml	2023-09-08 14:47:18.426826400 +0200
-@@ -70,6 +70,10 @@
+@@ -70,6 +70,11 @@
                 connectionTimeout="20000"
                 redirectPort="8443"
                 maxParameterCount="1000"
@@ -8,6 +8,7 @@
 +               proxyPort="TOMCAT_REVERSEPROXY_PORT"
 +               scheme="TOMCAT_REVERSEPROXY_SCHEME"
 +               secure="TOMCAT_REVERSEPROXY_SSL"
++               maxHttpHeaderSize="1000000"
                 />
      <!-- A "Connector" using the shared thread pool-->
      <!--


### PR DESCRIPTION
This fixes an issue with tomcat complaining about to large header sizes for the Authorization header, when sending an jwt access token.